### PR TITLE
add function to get input reference clock

### DIFF
--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -143,6 +143,10 @@ HRESULT decklink_input_set_callback(IDeckLinkInput* input, IDeckLinkInputCallbac
     return input->SetCallback(callback);
 }
 
+HRESULT decklink_input_get_hardware_reference_clock(IDeckLinkInput* input, BMDTimeScale timeScale, BMDTimeValue* hardwareTime, BMDTimeValue* timeInFrame, BMDTimeValue* ticksPerFrame) {
+    return input->GetHardwareReferenceClock(timeScale, hardwareTime, timeInFrame, ticksPerFrame);
+}
+
 HRESULT decklink_output_get_display_mode_iterator(IDeckLinkOutput* output, IDeckLinkDisplayModeIterator** iterator) {
 	return output->GetDisplayModeIterator(iterator);
 }

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -33,6 +33,7 @@ HRESULT decklink_input_enable_video_input(IDeckLinkInput* input, BMDDisplayMode 
 HRESULT decklink_input_disable_video_input(IDeckLinkInput* input);
 HRESULT decklink_input_disable_audio_input(IDeckLinkInput* input);
 HRESULT decklink_input_set_callback(IDeckLinkInput* input, IDeckLinkInputCallback* callback);
+HRESULT decklink_input_get_hardware_reference_clock(IDeckLinkInput* input, BMDTimeScale timeScale, BMDTimeValue* hardwareTime, BMDTimeValue* timeInFrame, BMDTimeValue* ticksPerFrame);
 
 HRESULT decklink_output_get_display_mode_iterator(IDeckLinkOutput* output, IDeckLinkDisplayModeIterator** iterator);
 HRESULT decklink_output_create_video_frame(IDeckLinkOutput* output, int32_t width, int32_t height, int32_t rowBytes, BMDPixelFormat pixelFormat, BMDFrameFlags flags, IDeckLinkMutableVideoFrame **outFrame);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1072,6 +1072,25 @@ impl Input {
     pub fn disable_audio_input(&mut self) -> Result<(), Error> {
         unsafe { void_result(decklink_input_disable_audio_input(self.implementation)) }
     }
+
+    pub fn get_hardware_reference_clock(
+        &mut self,
+        time_scale: i64,
+    ) -> Result<(i64, i64, i64), Error> {
+        let mut hardware_time = 0;
+        let mut time_in_frame = 0;
+        let mut ticks_per_frame = 0;
+        unsafe {
+            void_result(decklink_input_get_hardware_reference_clock(
+                self.implementation,
+                time_scale,
+                &mut hardware_time,
+                &mut time_in_frame,
+                &mut ticks_per_frame,
+            ))?;
+        }
+        Ok((hardware_time, time_in_frame, ticks_per_frame))
+    }
 }
 
 pub struct Output {


### PR DESCRIPTION
Adds a function to get an input's hardware reference clock.

The hardware reference appears to provide the DeckLink's uptime, but the docs make it clear it should only be used for measuring elapsed time and for measurements involving other hardware reference timestamps.