### PR TITLE
hide BMDDeckLinkAPIInformationID from APIInformation methods

### DIFF
--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -386,19 +386,11 @@ IDeckLinkAPIInformation* create_decklink_api_information_instance() {
 	return CreateDeckLinkAPIInformationInstance();
 }
 
-HRESULT decklink_api_information_get_flag(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, bool* value) {
-    return apiInfo->GetFlag(cfgID, value);
-}
-
-HRESULT decklink_api_information_get_int(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, int64_t* value) {
+HRESULT decklink_api_information_get_version_int(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, int64_t* value) {
     return apiInfo->GetInt(cfgID, value);
 }
 
-HRESULT decklink_api_information_get_float(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, double* value) {
-    return apiInfo->GetFloat(cfgID, value);
-}
-
-HRESULT decklink_api_information_get_string(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, Buffer** value) {
+HRESULT decklink_api_information_get_version_string(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, Buffer** value) {
     return apiInfo->GetString(cfgID, StringArg(value));
 }
 

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -77,10 +77,8 @@ HRESULT decklink_timecode_get_components(IDeckLinkTimecode* timecode, uint8_t* h
 HRESULT decklink_timecode_get_string(IDeckLinkTimecode* timecode, Buffer** value);
 
 IDeckLinkAPIInformation* create_decklink_api_information_instance();
-HRESULT decklink_api_information_get_flag(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, bool* value);
-HRESULT decklink_api_information_get_int(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, int64_t* value);
-HRESULT decklink_api_information_get_float(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, double* value);
-HRESULT decklink_api_information_get_string(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, Buffer** value);
+HRESULT decklink_api_information_get_version_int(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, int64_t* value);
+HRESULT decklink_api_information_get_version_string(IDeckLinkAPIInformation* apiInfo, BMDDeckLinkAPIInformationID cfgID, Buffer** value);
 
 const void* buffer_data(Buffer* str);
 void buffer_release(Buffer* str);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1666,40 +1666,40 @@ impl APIInformation {
         }
     }
 
-    pub fn get_flag(&self, id: BMDDeckLinkAPIInformationID) -> Result<bool, Error> {
+    pub fn get_flag(&self) -> Result<bool, Error> {
         unsafe {
             let mut v = false;
-            match decklink_api_information_get_flag(self.implementation, id, &mut v) {
+            match decklink_api_information_get_flag(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
                 0 => Ok(v),
                 result => Err(Error { result }),
             }
         }
     }
 
-    pub fn get_int(&self, id: BMDDeckLinkAPIInformationID) -> Result<i64, Error> {
+    pub fn get_int(&self) -> Result<i64, Error> {
         unsafe {
             let mut v = 0i64;
-            match decklink_api_information_get_int(self.implementation, id, &mut v) {
+            match decklink_api_information_get_int(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
                 0 => Ok(v),
                 result => Err(Error { result }),
             }
         }
     }
 
-    pub fn get_float(&self, id: BMDDeckLinkAPIInformationID) -> Result<f64, Error> {
+    pub fn get_float(&self) -> Result<f64, Error> {
         unsafe {
             let mut v = 0f64;
-            match decklink_api_information_get_float(self.implementation, id, &mut v) {
+            match decklink_api_information_get_float(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
                 0 => Ok(v),
                 result => Err(Error { result }),
             }
         }
     }
 
-    pub fn get_string(&self, id: BMDDeckLinkAPIInformationID) -> Result<String, Error> {
+    pub fn get_string(&self) -> Result<String, Error> {
         unsafe {
             let mut v: *mut Buffer = std::ptr::null_mut();
-            match decklink_api_information_get_string(self.implementation, id, &mut v) {
+            match decklink_api_information_get_string(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
                 0 => {
                     let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const i8)
                         .to_str()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1666,40 +1666,20 @@ impl APIInformation {
         }
     }
 
-    pub fn get_flag(&self) -> Result<bool, Error> {
-        unsafe {
-            let mut v = false;
-            match decklink_api_information_get_flag(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
-                0 => Ok(v),
-                result => Err(Error { result }),
-            }
-        }
-    }
-
-    pub fn get_int(&self) -> Result<i64, Error> {
+    pub fn get_version_int(&self) -> Result<i64, Error> {
         unsafe {
             let mut v = 0i64;
-            match decklink_api_information_get_int(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
+            match decklink_api_information_get_version_int(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
                 0 => Ok(v),
                 result => Err(Error { result }),
             }
         }
     }
 
-    pub fn get_float(&self) -> Result<f64, Error> {
-        unsafe {
-            let mut v = 0f64;
-            match decklink_api_information_get_float(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
-                0 => Ok(v),
-                result => Err(Error { result }),
-            }
-        }
-    }
-
-    pub fn get_string(&self) -> Result<String, Error> {
+    pub fn get_version_string(&self) -> Result<String, Error> {
         unsafe {
             let mut v: *mut Buffer = std::ptr::null_mut();
-            match decklink_api_information_get_string(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
+            match decklink_api_information_get_version_string(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
                 0 => {
                     let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const i8)
                         .to_str()


### PR DESCRIPTION
1. Client shouldn't know `BMDDeckLinkAPIInformationID` before calling the APIInformation methods.
2. Removed `BMDDeckLinkAPIVersion` flag and float methods