### PR TITLE
Use OS definition of c_char

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
     ffi::c_void,
     fmt,
     ops::{Deref, DerefMut},
+    os::raw::c_char,
 };
 
 use simple_error::SimpleError;
@@ -92,7 +93,7 @@ impl Device {
             let mut buf: *mut Buffer = std::ptr::null_mut();
             match decklink_get_model_name(self.implementation, &mut buf) {
                 0 => {
-                    let ret = std::ffi::CStr::from_ptr(buffer_data(buf) as *const i8)
+                    let ret = std::ffi::CStr::from_ptr(buffer_data(buf) as *const c_char)
                         .to_str()
                         .unwrap_or("")
                         .to_string();
@@ -375,7 +376,7 @@ impl Attributes {
             let mut v: *mut Buffer = std::ptr::null_mut();
             match decklink_attributes_get_string(self.implementation, id, &mut v) {
                 0 => {
-                    let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const i8)
+                    let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const c_char)
                         .to_str()
                         .unwrap_or("")
                         .to_string());
@@ -583,7 +584,7 @@ impl DisplayModeInfo {
             let mut buf: *mut Buffer = std::ptr::null_mut();
             match decklink_display_mode_get_name(self.implementation, &mut buf) {
                 0 => {
-                    let ret = std::ffi::CStr::from_ptr(buffer_data(buf) as *const i8)
+                    let ret = std::ffi::CStr::from_ptr(buffer_data(buf) as *const c_char)
                         .to_str()
                         .unwrap_or("")
                         .to_string();
@@ -1636,7 +1637,7 @@ impl Timecode {
         unsafe {
             let mut v: *mut Buffer = std::ptr::null_mut();
             void_result(decklink_timecode_get_string(self.implementation, &mut v))?;
-            let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const i8)
+            let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const c_char)
                 .to_str()
                 .unwrap_or("")
                 .to_string());
@@ -1681,7 +1682,7 @@ impl APIInformation {
             let mut v: *mut Buffer = std::ptr::null_mut();
             match decklink_api_information_get_version_string(self.implementation, _BMDDeckLinkAPIInformationID_BMDDeckLinkAPIVersion, &mut v) {
                 0 => {
-                    let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const i8)
+                    let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const c_char)
                         .to_str()
                         .unwrap_or("")
                         .to_string());


### PR DESCRIPTION
c_char being u8 or i8 ends up being kind of os/arch dependent. We
shouldn't hardcode one or the other, we should ultimately depend on what
the C includes tell us is true.

Fixes the following bug on Linux ARM64:
```
error[E0308]: mismatched types
   --> /home/raven/.cargo/git/checkouts/decklink-rs-1ef0154a09905a18/c09af27/src/lib.rs:378:59
    |
378 |                     let ret = Ok(std::ffi::CStr::from_ptr(buffer_data(v) as *const i8)
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
```

Testing:
  - I can actuall build it now, on my test vm:
    ```
    [2:31:25  raven@nest:~/workspace/avs-agent]$ gcc -dumpmachine
    aarch64-linux-gnu
    ```